### PR TITLE
89955 - Add Info for compare set keyboard shortcuts to Help File

### DIFF
--- a/docs/key-functionality/visualise/atlas/system-operation/keyboard.md
+++ b/docs/key-functionality/visualise/atlas/system-operation/keyboard.md
@@ -173,4 +173,4 @@ The command to switch a page group to the 10th compare set (++ctrl+shift+0++) ma
 - Set "Switch keyboard layout" to "Not assigned".
 
 This change removes the OS-level binding that can block ++ctrl+shift+0++, allowing the application shortcut to work as expected.
-Also to note, for switching to set 15, on US keyboards you'll need to use the ++number-sign++ key instead of ++single-quote++.
+Also to note, for switching to set 15, on US keyboards you'll need to use the ++numbers-sign++ key instead of ++single-quote++.

--- a/docs/key-functionality/visualise/atlas/system-operation/keyboard.md
+++ b/docs/key-functionality/visualise/atlas/system-operation/keyboard.md
@@ -48,7 +48,7 @@
 | ++shift++ + ++semicolon++											| Select the Compare Set for the _active display_ (set 14)                                |
 | ++shift++ + ++quote++												| Select the Compare Set for the _active display_ (set 15)                                |
 | ++shift++ + ++comma++												| Select the Compare Set for the _active display_ (set 16)                                |
-| ++shift++ + ++fullstop++											| Select the Compare Set for the _active display_ (set 17)                                |
+| ++shift++ + ++dot++											| Select the Compare Set for the _active display_ (set 17)                                |
 | ++shift++ + ++slash++												| Select the Compare Set for the _active display_ (set 18)                                |
 | ++shift+tab++														| Select the Compare Set for the _active display_ (set 19)                                |
 | ++shift+cap++														| Select the Compare Set for the _active display_ (set 20)

--- a/docs/key-functionality/visualise/atlas/system-operation/keyboard.md
+++ b/docs/key-functionality/visualise/atlas/system-operation/keyboard.md
@@ -42,7 +42,7 @@
 | ------------------------------------------------------------|---------------------------------------------------------------------------------------- |
 | ++shift+1++ … ++shift+9++                                   | Select the Compare Set for the _active display_                                         |
 | ++shift+0++                                                 | Select the Compare Set for the _active display_ (set 10*)                               |
-| ++shift++ + ++minus++                                         | Select the Compare Set for the _active display_ (set 11)                                |
+| ++shift++ + ++minus++                                       | Select the Compare Set for the _active display_ (set 11)                                |
 | ++shift+=++                                                 | Select the Compare Set for the _active display_ (set 12)                                |
 | ++shift+backspace++                                         | Select the Compare Set for the _active display_ (set 13)                                |
 | ++shift+;                                                   | Select the Compare Set for the _active display_ (set 14)                                |

--- a/docs/key-functionality/visualise/atlas/system-operation/keyboard.md
+++ b/docs/key-functionality/visualise/atlas/system-operation/keyboard.md
@@ -42,10 +42,10 @@
 | ------------------------------------------------------------|---------------------------------------------------------------------------------------- |
 | ++shift+1++ … ++shift+9++                                   | Select the Compare Set for the _active display_                                         |
 | ++shift+0++                                                 | Select the Compare Set for the _active display_ (set 10*)                               |
-| ++shift+-++                                                 | Select the Compare Set for the _active display_ (set 11)                                |
-| ++shift+=++                                                 | Select the Compare Set for the _active display_ (set 12)                                |
+| ++shift++++minus++                                          | Select the Compare Set for the _active display_ (set 11)                                |
+| ++shift++++equals++                                         | Select the Compare Set for the _active display_ (set 12)                                |
 | ++shift+backspace++                                         | Select the Compare Set for the _active display_ (set 13)                                |
-| ++shift+;++                                                 | Select the Compare Set for the _active display_ (set 14)                                |
+| — ++shift+;++ —                                             | Select the Compare Set for the _active display_ (set 14)                                |
 | ++shift+'++                                                 | Select the Compare Set for the _active display_ (set 15)                                |
 | ++shift+,++                                                 | Select the Compare Set for the _active display_ (set 16)                                |
 | ++shift+.++                                                 | Select the Compare Set for the _active display_ (set 17)                                |

--- a/docs/key-functionality/visualise/atlas/system-operation/keyboard.md
+++ b/docs/key-functionality/visualise/atlas/system-operation/keyboard.md
@@ -173,4 +173,4 @@ The command to switch a page group to the 10th compare set (++ctrl+shift+0++) ma
 - Set "Switch keyboard layout" to "Not assigned".
 
 This change removes the OS-level binding that can block ++ctrl+shift+0++, allowing the application shortcut to work as expected.
-Also to note, for switching to set 15, on US keyboards you'll need to use the ++hashkey++ key instead of ++single-quote++.
+Also to note, for switching to set 15, on US keyboards you'll need to use the ++number-sign++ key instead of ++single-quote++.

--- a/docs/key-functionality/visualise/atlas/system-operation/keyboard.md
+++ b/docs/key-functionality/visualise/atlas/system-operation/keyboard.md
@@ -46,7 +46,7 @@
 | ++shift++ + ++equal++												| Select the Compare Set for the _active display_ (set 12)                                |
 | ++shift+backspace++												| Select the Compare Set for the _active display_ (set 13)                                |
 | ++shift++ + ++semicolon++											| Select the Compare Set for the _active display_ (set 14)                                |
-| ++shift++ + ++singlequote++										| Select the Compare Set for the _active display_ (set 15)                                |
+| ++shift++ + ++contraction++										| Select the Compare Set for the _active display_ (set 15)                                |
 | ++shift++ + ++comma++												| Select the Compare Set for the _active display_ (set 16)                                |
 | ++shift++ + ++period++											| Select the Compare Set for the _active display_ (set 17)                                |
 | ++shift++ + ++slash++												| Select the Compare Set for the _active display_ (set 18)                                |
@@ -173,4 +173,4 @@ The command to switch a page group to the 10th compare set (Ctrl + Shift + 0) ma
 - Set "Switch keyboard layout" to "Not assigned".
 
 This change removes the OS-level binding that can block Ctrl + Shift + 0, allowing the application shortcut to work as expected.
-Also to note, for switching to set 15, on US keyboards you'll need to use the ++hash++ key instead of ++quote++.
+Also to note, for switching to set 15, on US keyboards you'll need to use the ++pound++ key instead of ++contraction++.

--- a/docs/key-functionality/visualise/atlas/system-operation/keyboard.md
+++ b/docs/key-functionality/visualise/atlas/system-operation/keyboard.md
@@ -42,7 +42,7 @@
 | ------------------------------------------------------------|---------------------------------------------------------------------------------------- |
 | ++shift+1++ … ++shift+9++                                   | Select the Compare Set for the _active display_                                         |
 | ++shift+0++                                                 | Select the Compare Set for the _active display_ (set 10*)                               |
-| ++shift+++++minus++                                         | Select the Compare Set for the _active display_ (set 11)                                |
+| ++shift++ + ++minus++                                         | Select the Compare Set for the _active display_ (set 11)                                |
 | ++shift+=++                                                 | Select the Compare Set for the _active display_ (set 12)                                |
 | ++shift+backspace++                                         | Select the Compare Set for the _active display_ (set 13)                                |
 | ++shift+;                                                   | Select the Compare Set for the _active display_ (set 14)                                |

--- a/docs/key-functionality/visualise/atlas/system-operation/keyboard.md
+++ b/docs/key-functionality/visualise/atlas/system-operation/keyboard.md
@@ -51,7 +51,7 @@
 | ++shift++ + ++.++                                           | Select the Compare Set for the _active display_ (set 17)                                |
 | ++shift++ + ++/++                                           | Select the Compare Set for the _active display_ (set 18)                                |
 | ++shift+tab++                                               | Select the Compare Set for the _active display_ (set 19)                                |
-| ++shift+capslock++                                          | Select the Compare Set for the _active display_ (set 20)                                |
+| ++shift+caps++                                              | Select the Compare Set for the _active display_ (set 20)                                |
 | ++ctrl+1++ … ++ctrl+9++                                     | Select the Compare Set for all displays on the _active page_                            |
 | ++ctrl+f1++ … ++ctrl+f9++                                   | Select the Compare Set for all displays in the _active page group_                      |
 | ++ctrl+shift+1++ … ++ctrl+shift+9++                         | Select the Compare Set for _all displays_                                               |

--- a/docs/key-functionality/visualise/atlas/system-operation/keyboard.md
+++ b/docs/key-functionality/visualise/atlas/system-operation/keyboard.md
@@ -48,7 +48,7 @@
 | ++shift++ + ++semicolon++											| Select the Compare Set for the _active display_ (set 14)                                |
 | ++shift++ + ++quote++												| Select the Compare Set for the _active display_ (set 15)                                |
 | ++shift++ + ++comma++												| Select the Compare Set for the _active display_ (set 16)                                |
-| ++shift++ + ++dot++											| Select the Compare Set for the _active display_ (set 17)                                |
+| ++shift++ + ++dot++											    | Select the Compare Set for the _active display_ (set 17)                                |
 | ++shift++ + ++slash++												| Select the Compare Set for the _active display_ (set 18)                                |
 | ++shift+tab++														| Select the Compare Set for the _active display_ (set 19)                                |
 | ++shift+cap++														| Select the Compare Set for the _active display_ (set 20)

--- a/docs/key-functionality/visualise/atlas/system-operation/keyboard.md
+++ b/docs/key-functionality/visualise/atlas/system-operation/keyboard.md
@@ -49,7 +49,7 @@
 | ++shift++ + ++apostrophe++                                  | Select the Compare Set for the _active display_ (set 15)                                |
 | ++shift++ + ++comma++                                       | Select the Compare Set for the _active display_ (set 16)                                |
 | ++shift++ + ++fullstop++                                    | Select the Compare Set for the _active display_ (set 17)                                |
-| ++shift++ + ++forwardslash++                                | Select the Compare Set for the _active display_ (set 18)                                |
+| ++shift++ + ++slash++                                       | Select the Compare Set for the _active display_ (set 18)                                |
 | ++shift+tab++                                               | Select the Compare Set for the _active display_ (set 19)                                |
 | ++shift+cap++                                               | Select the Compare Set for the _active display_ (set 20)                                |
 | ++ctrl+1++ … ++ctrl+9++                                     | Select the Compare Set for all displays on the _active page_                            |

--- a/docs/key-functionality/visualise/atlas/system-operation/keyboard.md
+++ b/docs/key-functionality/visualise/atlas/system-operation/keyboard.md
@@ -45,10 +45,10 @@
 | ++shift++ + ++minus++                                       | Select the Compare Set for the _active display_ (set 11)                                |
 | ++shift++ + ++equal++                                       | Select the Compare Set for the _active display_ (set 12)                                |
 | ++shift+backspace++                                         | Select the Compare Set for the _active display_ (set 13)                                |
-| ++shift++ + ++;++                                           | Select the Compare Set for the _active display_ (set 14)                                |
-| ++shift++ + ++'++                                           | Select the Compare Set for the _active display_ (set 15)                                |
-| ++shift++ + ++,++                                           | Select the Compare Set for the _active display_ (set 16)                                |
-| ++shift++ + ++.++                                           | Select the Compare Set for the _active display_ (set 17)                                |
+| ++shift++ + ++semicolon++                                   | Select the Compare Set for the _active display_ (set 14)                                |
+| ++shift++ + ++apostrophe++                                  | Select the Compare Set for the _active display_ (set 15)                                |
+| ++shift++ + ++comma++                                       | Select the Compare Set for the _active display_ (set 16)                                |
+| ++shift++ + ++fullstop++                                    | Select the Compare Set for the _active display_ (set 17)                                |
 | ++shift++ + ++/++                                           | Select the Compare Set for the _active display_ (set 18)                                |
 | ++shift+tab++                                               | Select the Compare Set for the _active display_ (set 19)                                |
 | ++shift+caps++                                              | Select the Compare Set for the _active display_ (set 20)                                |

--- a/docs/key-functionality/visualise/atlas/system-operation/keyboard.md
+++ b/docs/key-functionality/visualise/atlas/system-operation/keyboard.md
@@ -46,7 +46,7 @@
 | ++shift++ + ++equal++												| Select the Compare Set for the _active display_ (set 12)                                |
 | ++shift+backspace++												| Select the Compare Set for the _active display_ (set 13)                                |
 | ++shift++ + ++semicolon++											| Select the Compare Set for the _active display_ (set 14)                                |
-| ++shift++ + ++punctuation++										| Select the Compare Set for the _active display_ (set 15)                                |
+| ++shift++ + ++single-quote++										| Select the Compare Set for the _active display_ (set 15)                                |
 | ++shift++ + ++comma++												| Select the Compare Set for the _active display_ (set 16)                                |
 | ++shift++ + ++period++											| Select the Compare Set for the _active display_ (set 17)                                |
 | ++shift++ + ++slash++												| Select the Compare Set for the _active display_ (set 18)                                |

--- a/docs/key-functionality/visualise/atlas/system-operation/keyboard.md
+++ b/docs/key-functionality/visualise/atlas/system-operation/keyboard.md
@@ -173,4 +173,4 @@ The command to switch a page group to the 10th compare set (Ctrl + Shift + 0) ma
 - Set "Switch keyboard layout" to "Not assigned".
 
 This change removes the OS-level binding that can block Ctrl + Shift + 0, allowing the application shortcut to work as expected.
-Also to note, for switching to set 15, on US keyboards you'll need to use the ++pound++ key instead of ++contraction++.
+Also to note, for switching to set 15, on US keyboards you'll need to use the ++number++ key instead of ++contraction++.

--- a/docs/key-functionality/visualise/atlas/system-operation/keyboard.md
+++ b/docs/key-functionality/visualise/atlas/system-operation/keyboard.md
@@ -173,4 +173,4 @@ The command to switch a page group to the 10th compare set (++ctrl+shift+0++) ma
 - Set "Switch keyboard layout" to "Not assigned".
 
 This change removes the OS-level binding that can block ++ctrl+shift+0++, allowing the application shortcut to work as expected.
-Also to note, for switching to set 15, on US keyboards you'll need to use the ++pound-sign++ key instead of ++single-quote++.
+Also to note, for switching to set 15, on US keyboards you'll need to use the ++hashtag++ key instead of ++single-quote++.

--- a/docs/key-functionality/visualise/atlas/system-operation/keyboard.md
+++ b/docs/key-functionality/visualise/atlas/system-operation/keyboard.md
@@ -40,13 +40,24 @@
 
 | Shortcut                                                    | Description                                                                             |
 | ------------------------------------------------------------|---------------------------------------------------------------------------------------- |
-| ++shift+1++ &#8230; ++9++                                   | Select the Compare Set for the _active display_                                         |
-| ++ctrl+1++ &#8230;​ ++9++                                    | Select the Compare Set for all displays on the _active page_                            |
-| ++ctrl+f1++ &#8230; ++f9++                                  | Select the Compare Set for all displays in the _active page group_                      |
-| ++ctrl+shift+1++ &#8230; ++9++                              | Select the Compare Set for _all displays_                                               |
-| ++shift+minus++                                             | Clears the Compare Set for the _active display_                                         |
-| ++ctrl+minus++                                              | Clears the Compare Set for all displays on the _active page_                            |
-| ++ctrl+shift+minus++ <br> ++ctrl+alt+shift+minus++          | Clears the Compare Set for all displays in the active _page group_                      |
+| ++shift+1++ … ++shift+9++                                   | Select the Compare Set for the _active display_                                         |
+| ++shift+0++                                                 | Select the Compare Set for the _active display_ (set 10*)                               |
+| ++shift+-++                                                 | Select the Compare Set for the _active display_ (set 11)                                |
+| ++shift+=++                                                 | Select the Compare Set for the _active display_ (set 12)                                |
+| ++shift+backspace++                                         | Select the Compare Set for the _active display_ (set 13)                                |
+| ++shift+;++                                                 | Select the Compare Set for the _active display_ (set 14)                                |
+| ++shift+'++                                                 | Select the Compare Set for the _active display_ (set 15)                                |
+| ++shift+,++                                                 | Select the Compare Set for the _active display_ (set 16)                                |
+| ++shift+.++                                                 | Select the Compare Set for the _active display_ (set 17)                                |
+| ++shift+/++                                                 | Select the Compare Set for the _active display_ (set 18)                                |
+| ++shift+tab++                                               | Select the Compare Set for the _active display_ (set 19)                                |
+| ++shift+capslock++                                          | Select the Compare Set for the _active display_ (set 20)                                |
+| ++ctrl+1++ … ++ctrl+9++                                     | Select the Compare Set for all displays on the _active page_                            |
+| ++ctrl+f1++ … ++ctrl+f9++                                   | Select the Compare Set for all displays in the _active page group_                      |
+| ++ctrl+shift+1++ … ++ctrl+shift+9++                         | Select the Compare Set for _all displays_                                               |
+| ++shift+delete++                                            | Clears the Compare Set for the _active display_                                         |
+| ++ctrl+delete++                                             | Clears the Compare Set for all displays on the _active page_                            |
+| ++ctrl+shift+delete++ or ++ctrl+alt+shift+delete++          | Clears the Compare Set for all displays in the active _page group_                      |
 
 ## Timeline and Navigation
 
@@ -149,3 +160,14 @@
 | ++escape++                                                  | Cancel zoom box                                                                         |
 | ++ctrl+p++                                                  | Print                                                                                   |
 | ++ctrl+shift+p++                                            | Print Preview                                                                           |
+
+### Known issue (Windows 11)
+
+The command to switch a page group to the 10th compare set (Ctrl + Shift + 0) may not work on some Windows 11 systems due to a system-level language hotkey using the same combination. To restore the shortcut, disable the language hotkeys:
+
+- Open Windows Settings > Typing > Advanced keyboard settings.
+- Click "Input language hot keys".
+- Select "Between input languages" or "Keyboard layout" and click "Change Key Sequence".
+- Set "Switch keyboard layout" to "Not assigned".
+
+This change removes the OS-level binding that can block Ctrl + Shift + 0, allowing the application shortcut to work as expected.

--- a/docs/key-functionality/visualise/atlas/system-operation/keyboard.md
+++ b/docs/key-functionality/visualise/atlas/system-operation/keyboard.md
@@ -46,12 +46,12 @@
 | ++shift++ + ++equal++												| Select the Compare Set for the _active display_ (set 12)                                |
 | ++shift+backspace++												| Select the Compare Set for the _active display_ (set 13)                                |
 | ++shift++ + ++semicolon++											| Select the Compare Set for the _active display_ (set 14)                                |
-| ++shift++ + ++quote++												| Select the Compare Set for the _active display_ (set 15)                                |
+| ++shift++ + ++singlequote++										| Select the Compare Set for the _active display_ (set 15)                                |
 | ++shift++ + ++comma++												| Select the Compare Set for the _active display_ (set 16)                                |
 | ++shift++ + ++period++											| Select the Compare Set for the _active display_ (set 17)                                |
 | ++shift++ + ++slash++												| Select the Compare Set for the _active display_ (set 18)                                |
 | ++shift+tab++														| Select the Compare Set for the _active display_ (set 19)                                |
-| ++shift+cap++														| Select the Compare Set for the _active display_ (set 20)
+| ++shift+capital++													| Select the Compare Set for the _active display_ (set 20)
 | ++ctrl+1++ … ++ctrl+9++											| Select the Compare Set for all displays on the _active page_
 | ++ctrl++ + same order of keyboard characters listed above			| Select the Compare Set for all displays on the _active page_ (sets 10-20)               |
 | ++ctrl+f1++ … ++ctrl+f9++											| Select the Compare Set for all displays in the _active page group_

--- a/docs/key-functionality/visualise/atlas/system-operation/keyboard.md
+++ b/docs/key-functionality/visualise/atlas/system-operation/keyboard.md
@@ -45,13 +45,13 @@
 | ++shift+++++minus++                                         | Select the Compare Set for the _active display_ (set 11)                                |
 | ++shift+=++                                                 | Select the Compare Set for the _active display_ (set 12)                                |
 | ++shift+backspace++                                         | Select the Compare Set for the _active display_ (set 13)                                |
-| — ++shift++++;++ —                                          | Select the Compare Set for the _active display_ (set 14)                                |
+| ++shift+;                                                   | Select the Compare Set for the _active display_ (set 14)                                |
 | ++shift+'++                                                 | Select the Compare Set for the _active display_ (set 15)                                |
 | ++shift+,++                                                 | Select the Compare Set for the _active display_ (set 16)                                |
 | ++shift+.++                                                 | Select the Compare Set for the _active display_ (set 17)                                |
 | ++shift+/++                                                 | Select the Compare Set for the _active display_ (set 18)                                |
 | ++shift+tab++                                               | Select the Compare Set for the _active display_ (set 19)                                |
-| ++shift+capslock++                                          | Select the Compare Set for the _active display_ (set 20)                                |
+| ++shift+caplocks++                                          | Select the Compare Set for the _active display_ (set 20)                                |
 | ++ctrl+1++ … ++ctrl+9++                                     | Select the Compare Set for all displays on the _active page_                            |
 | ++ctrl+f1++ … ++ctrl+f9++                                   | Select the Compare Set for all displays in the _active page group_                      |
 | ++ctrl+shift+1++ … ++ctrl+shift+9++                         | Select the Compare Set for _all displays_                                               |

--- a/docs/key-functionality/visualise/atlas/system-operation/keyboard.md
+++ b/docs/key-functionality/visualise/atlas/system-operation/keyboard.md
@@ -173,4 +173,4 @@ The command to switch a page group to the 10th compare set (++ctrl+shift+0++) ma
 - Set "Switch keyboard layout" to "Not assigned".
 
 This change removes the OS-level binding that can block ++ctrl+shift+0++, allowing the application shortcut to work as expected.
-Also to note, for switching to set 15, on US keyboards you'll need to use the ++numbers-sign++ key instead of ++single-quote++.
+Also to note, for switching to set 15, on US keyboards you'll need to use the ++pound-sign++ key instead of ++single-quote++.

--- a/docs/key-functionality/visualise/atlas/system-operation/keyboard.md
+++ b/docs/key-functionality/visualise/atlas/system-operation/keyboard.md
@@ -43,15 +43,15 @@
 | ++shift+1++ … ++shift+9++                                   | Select the Compare Set for the _active display_                                         |
 | ++shift+0++                                                 | Select the Compare Set for the _active display_ (set 10*)                               |
 | ++shift++ + ++minus++                                       | Select the Compare Set for the _active display_ (set 11)                                |
-| ++shift+=++                                                 | Select the Compare Set for the _active display_ (set 12)                                |
+| ++shift++ + ++equal++                                       | Select the Compare Set for the _active display_ (set 12)                                |
 | ++shift+backspace++                                         | Select the Compare Set for the _active display_ (set 13)                                |
-| ++shift+;                                                   | Select the Compare Set for the _active display_ (set 14)                                |
-| ++shift+'++                                                 | Select the Compare Set for the _active display_ (set 15)                                |
-| ++shift+,++                                                 | Select the Compare Set for the _active display_ (set 16)                                |
-| ++shift+.++                                                 | Select the Compare Set for the _active display_ (set 17)                                |
-| ++shift+/++                                                 | Select the Compare Set for the _active display_ (set 18)                                |
+| ++shift++ + ++;++                                           | Select the Compare Set for the _active display_ (set 14)                                |
+| ++shift++ + ++'++                                           | Select the Compare Set for the _active display_ (set 15)                                |
+| ++shift++ + ++,++                                           | Select the Compare Set for the _active display_ (set 16)                                |
+| ++shift++ + ++.++                                           | Select the Compare Set for the _active display_ (set 17)                                |
+| ++shift++ + ++/++                                           | Select the Compare Set for the _active display_ (set 18)                                |
 | ++shift+tab++                                               | Select the Compare Set for the _active display_ (set 19)                                |
-| ++shift+caplocks++                                          | Select the Compare Set for the _active display_ (set 20)                                |
+| ++shift+capslock++                                          | Select the Compare Set for the _active display_ (set 20)                                |
 | ++ctrl+1++ … ++ctrl+9++                                     | Select the Compare Set for all displays on the _active page_                            |
 | ++ctrl+f1++ … ++ctrl+f9++                                   | Select the Compare Set for all displays in the _active page group_                      |
 | ++ctrl+shift+1++ … ++ctrl+shift+9++                         | Select the Compare Set for _all displays_                                               |

--- a/docs/key-functionality/visualise/atlas/system-operation/keyboard.md
+++ b/docs/key-functionality/visualise/atlas/system-operation/keyboard.md
@@ -48,7 +48,7 @@
 | ++shift++ + ++semicolon++											| Select the Compare Set for the _active display_ (set 14)                                |
 | ++shift++ + ++quote++												| Select the Compare Set for the _active display_ (set 15)                                |
 | ++shift++ + ++comma++												| Select the Compare Set for the _active display_ (set 16)                                |
-| ++shift++ + ++dot++											    | Select the Compare Set for the _active display_ (set 17)                                |
+| ++shift++ + ++period++											| Select the Compare Set for the _active display_ (set 17)                                |
 | ++shift++ + ++slash++												| Select the Compare Set for the _active display_ (set 18)                                |
 | ++shift+tab++														| Select the Compare Set for the _active display_ (set 19)                                |
 | ++shift+cap++														| Select the Compare Set for the _active display_ (set 20)

--- a/docs/key-functionality/visualise/atlas/system-operation/keyboard.md
+++ b/docs/key-functionality/visualise/atlas/system-operation/keyboard.md
@@ -173,4 +173,4 @@ The command to switch a page group to the 10th compare set (++ctrl+shift+0++) ma
 - Set "Switch keyboard layout" to "Not assigned".
 
 This change removes the OS-level binding that can block ++ctrl+shift+0++, allowing the application shortcut to work as expected.
-Also to note, for switching to set 15, on US keyboards you'll need to use the ++hashtag++ key instead of ++single-quote++.
+Also to note, for switching to set 15, on US keyboards you'll need to use the # key instead of ++single-quote++.

--- a/docs/key-functionality/visualise/atlas/system-operation/keyboard.md
+++ b/docs/key-functionality/visualise/atlas/system-operation/keyboard.md
@@ -49,9 +49,9 @@
 | ++shift++ + ++apostrophe++                                  | Select the Compare Set for the _active display_ (set 15)                                |
 | ++shift++ + ++comma++                                       | Select the Compare Set for the _active display_ (set 16)                                |
 | ++shift++ + ++fullstop++                                    | Select the Compare Set for the _active display_ (set 17)                                |
-| ++shift++ + ++/++                                           | Select the Compare Set for the _active display_ (set 18)                                |
+| ++shift++ + ++forwardslash++                                | Select the Compare Set for the _active display_ (set 18)                                |
 | ++shift+tab++                                               | Select the Compare Set for the _active display_ (set 19)                                |
-| ++shift+caps++                                              | Select the Compare Set for the _active display_ (set 20)                                |
+| ++shift+cap++                                               | Select the Compare Set for the _active display_ (set 20)                                |
 | ++ctrl+1++ … ++ctrl+9++                                     | Select the Compare Set for all displays on the _active page_                            |
 | ++ctrl+f1++ … ++ctrl+f9++                                   | Select the Compare Set for all displays in the _active page group_                      |
 | ++ctrl+shift+1++ … ++ctrl+shift+9++                         | Select the Compare Set for _all displays_                                               |

--- a/docs/key-functionality/visualise/atlas/system-operation/keyboard.md
+++ b/docs/key-functionality/visualise/atlas/system-operation/keyboard.md
@@ -46,7 +46,7 @@
 | ++shift++ + ++equal++												| Select the Compare Set for the _active display_ (set 12)                                |
 | ++shift+backspace++												| Select the Compare Set for the _active display_ (set 13)                                |
 | ++shift++ + ++semicolon++											| Select the Compare Set for the _active display_ (set 14)                                |
-| ++shift++ + ++contraction++										| Select the Compare Set for the _active display_ (set 15)                                |
+| ++shift++ + ++punctuation++										| Select the Compare Set for the _active display_ (set 15)                                |
 | ++shift++ + ++comma++												| Select the Compare Set for the _active display_ (set 16)                                |
 | ++shift++ + ++period++											| Select the Compare Set for the _active display_ (set 17)                                |
 | ++shift++ + ++slash++												| Select the Compare Set for the _active display_ (set 18)                                |

--- a/docs/key-functionality/visualise/atlas/system-operation/keyboard.md
+++ b/docs/key-functionality/visualise/atlas/system-operation/keyboard.md
@@ -165,12 +165,12 @@
 
 ### Known issue (Windows 11)
 
-The command to switch a page group to the 10th compare set (Ctrl + Shift + 0) may not work on some Windows 11 systems due to a system-level language hotkey using the same combination. To restore the shortcut, disable the language hotkeys:
+The command to switch a page group to the 10th compare set (++ctrl+shift+0++) may not work on some Windows 11 systems due to a system-level language hotkey using the same combination. To restore the shortcut, disable the language hotkeys:
 
 - Open Windows Settings > Typing > Advanced keyboard settings.
 - Click "Input language hot keys".
 - Select "Between input languages" or "Keyboard layout" and click "Change Key Sequence".
 - Set "Switch keyboard layout" to "Not assigned".
 
-This change removes the OS-level binding that can block Ctrl + Shift + 0, allowing the application shortcut to work as expected.
-Also to note, for switching to set 15, on US keyboards you'll need to use the # key instead of '.
+This change removes the OS-level binding that can block ++ctrl+shift+0++, allowing the application shortcut to work as expected.
+Also to note, for switching to set 15, on US keyboards you'll need to use the ++hashkey++ key instead of ++single-quote++.

--- a/docs/key-functionality/visualise/atlas/system-operation/keyboard.md
+++ b/docs/key-functionality/visualise/atlas/system-operation/keyboard.md
@@ -38,26 +38,28 @@
 
 ### Associating Compare Sets
 
-| Shortcut                                                    | Description                                                                             |
-| ------------------------------------------------------------|---------------------------------------------------------------------------------------- |
-| ++shift+1++ … ++shift+9++                                   | Select the Compare Set for the _active display_                                         |
-| ++shift+0++                                                 | Select the Compare Set for the _active display_ (set 10*)                               |
-| ++shift++ + ++minus++                                       | Select the Compare Set for the _active display_ (set 11)                                |
-| ++shift++ + ++equal++                                       | Select the Compare Set for the _active display_ (set 12)                                |
-| ++shift+backspace++                                         | Select the Compare Set for the _active display_ (set 13)                                |
-| ++shift++ + ++semicolon++                                   | Select the Compare Set for the _active display_ (set 14)                                |
-| ++shift++ + ++apostrophe++                                  | Select the Compare Set for the _active display_ (set 15)                                |
-| ++shift++ + ++comma++                                       | Select the Compare Set for the _active display_ (set 16)                                |
-| ++shift++ + ++fullstop++                                    | Select the Compare Set for the _active display_ (set 17)                                |
-| ++shift++ + ++slash++                                       | Select the Compare Set for the _active display_ (set 18)                                |
-| ++shift+tab++                                               | Select the Compare Set for the _active display_ (set 19)                                |
-| ++shift+cap++                                               | Select the Compare Set for the _active display_ (set 20)                                |
-| ++ctrl+1++ … ++ctrl+9++                                     | Select the Compare Set for all displays on the _active page_                            |
-| ++ctrl+f1++ … ++ctrl+f9++                                   | Select the Compare Set for all displays in the _active page group_                      |
-| ++ctrl+shift+1++ … ++ctrl+shift+9++                         | Select the Compare Set for _all displays_                                               |
-| ++shift+delete++                                            | Clears the Compare Set for the _active display_                                         |
-| ++ctrl+delete++                                             | Clears the Compare Set for all displays on the _active page_                            |
-| ++ctrl+shift+delete++ or ++ctrl+alt+shift+delete++          | Clears the Compare Set for all displays in the active _page group_                      |
+| Shortcut															| Description                                                                             |
+| ------------------------------------------------------------------|---------------------------------------------------------------------------------------- |
+| ++shift+1++ … ++shift+9++											| Select the Compare Set for the _active display_                                         |
+| ++shift+0++														| Select the Compare Set for the _active display_ (set 10*)                               |
+| ++shift++ + ++minus++												| Select the Compare Set for the _active display_ (set 11)                                |
+| ++shift++ + ++equal++												| Select the Compare Set for the _active display_ (set 12)                                |
+| ++shift+backspace++												| Select the Compare Set for the _active display_ (set 13)                                |
+| ++shift++ + ++semicolon++											| Select the Compare Set for the _active display_ (set 14)                                |
+| ++shift++ + ++quote++												| Select the Compare Set for the _active display_ (set 15)                                |
+| ++shift++ + ++comma++												| Select the Compare Set for the _active display_ (set 16)                                |
+| ++shift++ + ++fullstop++											| Select the Compare Set for the _active display_ (set 17)                                |
+| ++shift++ + ++slash++												| Select the Compare Set for the _active display_ (set 18)                                |
+| ++shift+tab++														| Select the Compare Set for the _active display_ (set 19)                                |
+| ++shift+cap++														| Select the Compare Set for the _active display_ (set 20)
+| ++ctrl+1++ … ++ctrl+9++											| Select the Compare Set for all displays on the _active page_
+| ++ctrl++ + same order of keyboard characters listed above			| Select the Compare Set for all displays on the _active page_ (sets 10-20)               |
+| ++ctrl+f1++ … ++ctrl+f9++											| Select the Compare Set for all displays in the _active page group_
+| ++ctrl+shift+1++ … ++ctrl+shift+9++								| Select the Compare Set for _all displays_
+| ++ctrl+shift++ + same order of keyboard characters listed above   | Select the Compare Set for _all displays_ (sets 10-20)                                    |
+| ++shift+delete++													| Clears the Compare Set for the _active display_                                         |
+| ++ctrl+delete++													| Clears the Compare Set for all displays on the _active page_                            |
+| ++ctrl+shift+delete++ or ++ctrl+alt+shift+delete++				| Clears the Compare Set for all displays in the active _page group_                      |
 
 ## Timeline and Navigation
 
@@ -171,3 +173,4 @@ The command to switch a page group to the 10th compare set (Ctrl + Shift + 0) ma
 - Set "Switch keyboard layout" to "Not assigned".
 
 This change removes the OS-level binding that can block Ctrl + Shift + 0, allowing the application shortcut to work as expected.
+Also to note, for switching to set 15, on US keyboards you'll need to use the ++hash++ key instead of ++quote++.

--- a/docs/key-functionality/visualise/atlas/system-operation/keyboard.md
+++ b/docs/key-functionality/visualise/atlas/system-operation/keyboard.md
@@ -42,10 +42,10 @@
 | ------------------------------------------------------------|---------------------------------------------------------------------------------------- |
 | ++shift+1++ … ++shift+9++                                   | Select the Compare Set for the _active display_                                         |
 | ++shift+0++                                                 | Select the Compare Set for the _active display_ (set 10*)                               |
-| ++shift++++minus++                                          | Select the Compare Set for the _active display_ (set 11)                                |
-| ++shift++++equals++                                         | Select the Compare Set for the _active display_ (set 12)                                |
+| ++shift+++++minus++                                         | Select the Compare Set for the _active display_ (set 11)                                |
+| ++shift+=++                                                 | Select the Compare Set for the _active display_ (set 12)                                |
 | ++shift+backspace++                                         | Select the Compare Set for the _active display_ (set 13)                                |
-| — ++shift+;++ —                                             | Select the Compare Set for the _active display_ (set 14)                                |
+| — ++shift++++;++ —                                          | Select the Compare Set for the _active display_ (set 14)                                |
 | ++shift+'++                                                 | Select the Compare Set for the _active display_ (set 15)                                |
 | ++shift+,++                                                 | Select the Compare Set for the _active display_ (set 16)                                |
 | ++shift+.++                                                 | Select the Compare Set for the _active display_ (set 17)                                |

--- a/docs/key-functionality/visualise/atlas/system-operation/keyboard.md
+++ b/docs/key-functionality/visualise/atlas/system-operation/keyboard.md
@@ -173,4 +173,4 @@ The command to switch a page group to the 10th compare set (Ctrl + Shift + 0) ma
 - Set "Switch keyboard layout" to "Not assigned".
 
 This change removes the OS-level binding that can block Ctrl + Shift + 0, allowing the application shortcut to work as expected.
-Also to note, for switching to set 15, on US keyboards you'll need to use the ++number++ key instead of ++contraction++.
+Also to note, for switching to set 15, on US keyboards you'll need to use the # key instead of '.


### PR DESCRIPTION
I forgot to include documentation for newly added keyboard shortcuts to change associations to any sets numbered between 10 and 20.