### PR TITLE
Update Open Streaming example docs

### DIFF
--- a/docs/developer-resources/secu4/stream_api/index.md
+++ b/docs/developer-resources/secu4/stream_api/index.md
@@ -56,8 +56,9 @@ var streamConfiguration = new StreamingApiConfiguration(
     integrateSessionManagement: true,
     batchingResponses: false);
 
-StreamingApiClient.Initialise(streamConfiguration, cancellationTokenProvider, 
+var streamingApiClient = StreamingApiClientFactory.Create(streamConfiguration, cancellationTokenProvider, 
     brokerChecker, loggingProvider);
+streamingApiClient.Initialise();
 ```
 
 #### Remote Docker Server
@@ -91,12 +92,13 @@ var configuration = new StreamingApiConfiguration(
     "localhost:9092",
     []);
 
-StreamingApiClient.Initialise(configuration, tokenProvider, brokerChecker, loggingProvider);
+var streamingApiClient = StreamingApiClientFactory.Create(configuration, tokenProvider, brokerChecker, loggingProvider);
+streamingApiClient.Initialise();
 
 // Get service clients
-var connectionManager = StreamingApiClient.GetConnectionManagerClient();
-var packetWriter = StreamingApiClient.GetPacketWriterClient();
-var packetReader = StreamingApiClient.GetPacketReaderClient();
+var connectionManager = streamingApiClient.GetConnectionManagerClient();
+var packetWriter = streamingApiClient.GetPacketWriterClient();
+var packetReader = streamingApiClient.GetPacketReaderClient();
 
 // Create connection
 var connection = await connectionManager.NewConnectionAsync(new NewConnectionRequest
@@ -242,7 +244,7 @@ Manages the lifecycle of data sessions, including creation, monitoring, and term
 
 #### Example Usage
 ```csharp
-var sessionManager = StreamingApiClient.GetSessionManagementClient();
+var sessionManager = streamingApiClient.GetSessionManagementClient();
 
 // Create a new session
 var newSession = await sessionManager.CreateSessionAsync(new CreateSessionRequest
@@ -284,7 +286,7 @@ Handles client connections to data sessions with unique connection tracking.
 
 #### Example Usage
 ```csharp
-var connectionManager = StreamingApiClient.GetConnectionManagerClient();
+var connectionManager = streamingApiClient.GetConnectionManagerClient();
 
 // Create new connection
 var connection = await connectionManager.NewConnectionAsync(new NewConnectionRequest
@@ -324,7 +326,7 @@ Enables high-performance data publishing to Kafka topics with support for both i
 
 #### Example Usage
 ```csharp
-var packetWriter = StreamingApiClient.GetPacketWriterClient();
+var packetWriter = streamingApiClient.GetPacketWriterClient();
 
 // Write single packet
 await packetWriter.WriteDataPacketAsync(new WriteDataPacketRequest
@@ -378,7 +380,7 @@ Provides flexible data consumption with three reading modes: all packets, essent
 
 #### Example Usage
 ```csharp
-var packetReader = StreamingApiClient.GetPacketReaderClient();
+var packetReader = streamingApiClient.GetPacketReaderClient();
 
 // Read all packets
 var readStream = packetReader.ReadPackets(new ReadPacketsRequest
@@ -427,7 +429,7 @@ Manages data schemas for parameters and events, enabling efficient data serializ
 
 #### Example Usage
 ```csharp
-var dataFormatManager = StreamingApiClient.GetDataFormatManagerClient();
+var dataFormatManager = streamingApiClient.GetDataFormatManagerClient();
 
 // Register parameter data format
 var parameterFormat = await dataFormatManager.GetParameterDataFormatIdAsync(
@@ -555,7 +557,7 @@ public class TelemetryExample
         var readingTask = StartReading(connection);
         
         // 5. Write telemetry data
-        await WriteTelemtryData();
+        await WriteTelemetryData();
         
         // 6. Wait for reading to complete
         await readingTask;
@@ -578,13 +580,19 @@ public class TelemetryExample
         var brokerChecker = new KafkaBrokerAvailabilityChecker();
         var loggingProvider = new LoggingDirectoryProvider("");
 
-        StreamingApiClient.Initialise(configuration, tokenProvider, brokerChecker, loggingProvider);
+        var streamingApiClient = StreamingApiClientFactory.Create(
+            configuration,
+            tokenProvider,
+            brokerChecker,
+            loggingProvider
+        )
+        streamingApiClient.Initialise()
 
         // Get service clients
-        packetWriter = StreamingApiClient.GetPacketWriterClient();
-        packetReader = StreamingApiClient.GetPacketReaderClient();
-        connectionManager = StreamingApiClient.GetConnectionManagerClient();
-        dataFormatManager = StreamingApiClient.GetDataFormatManagerClient();
+        packetWriter = streamingApiClient.GetPacketWriterClient();
+        packetReader = streamingApiClient.GetPacketReaderClient();
+        connectionManager = streamingApiClient.GetConnectionManagerClient();
+        dataFormatManager = streamingApiClient.GetDataFormatManagerClient();
     }
 
     private async Task<NewConnectionResponse> CreateConnection()
@@ -648,7 +656,7 @@ public class TelemetryExample
         }
     }
 
-    private async Task WriteTelemtryData()
+    private async Task WriteTelemetryData()
     {
         var sessionKey = $"Session_{DateTime.UtcNow:yyyyMMdd_HHmmss}";
         var random = new Random();

--- a/docs/developer-resources/secu4/stream_api/reference_docs/examples/telemetry-example.md
+++ b/docs/developer-resources/secu4/stream_api/reference_docs/examples/telemetry-example.md
@@ -443,12 +443,14 @@ public class TelemetryProducer
 
     public TelemetryProducer(StreamingApiConfiguration configuration, string vehicleId)
     {
-        StreamingApiClient.Initialise(
+        var streamingApiClient = StreamingApiClientFactory.Create(
             configuration,
             new CancellationTokenSourceProvider(),
             new KafkaBrokerAvailabilityChecker(),
             new LoggingDirectoryProvider(@"C:\Temp"));
-        var sessionManagement = StreamingApiClient.GetSessionManagementClient();
+        streamingApiClient.Initialise();
+
+        var sessionManagement = streamingApiClient.GetSessionManagementClient();
         var response = sessionManagement.CreateSession(
             new CreateSessionRequest
             {
@@ -475,7 +477,7 @@ public class TelemetryProducer
             });
 
         Console.WriteLine($"Session {response.SessionKey} created.");
-        this.packetWriter = StreamingApiClient.GetPacketWriterClient();
+        this.packetWriter = streamingApiClient.GetPacketWriterClient();
         this.vehicleId = vehicleId;
         this.SessionKey = response.SessionKey;
         this.DataSource = vehicleId;
@@ -762,20 +764,23 @@ public class TelemetryProcessor
     private readonly string dataSource;
     private readonly string sessionKey;
     private readonly PacketReaderService.PacketReaderServiceClient packetReader;
+    private readonly PacketWriterService.PacketWriterServiceClient packetWriter;
     private readonly ConnectionManagerService.ConnectionManagerServiceClient connectionManager;
 
     public TelemetryProcessor(StreamingApiConfiguration configuration, string dataSource, string sessionKey)
     {
         this.dataSource = dataSource;
         this.sessionKey = sessionKey;
-        StreamingApiClient.Initialise(
+        var streamingApiClient = StreamingApiClientFactory.Create(
             configuration,
             new CancellationTokenSourceProvider(),
             new KafkaBrokerAvailabilityChecker(),
             new LoggingDirectoryProvider(@"C:\Temp"));
+        streamingApiClient.Initialise();
 
-        this.packetReader = StreamingApiClient.GetPacketReaderClient();
-        this.connectionManager = StreamingApiClient.GetConnectionManagerClient();
+        this.packetReader = streamingApiClient.GetPacketReaderClient();
+        this.packetWriter = streamingApiClient.GetPacketWriterClient();
+        this.connectionManager = streamingApiClient.GetConnectionManagerClient();
     }
 
     public async Task StartProcessing(CancellationToken cancellationToken = default)
@@ -1048,7 +1053,7 @@ public class TelemetryProcessor
             Timestamp = (ulong)DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() * 1000000
         };
 
-        var packetWriter = StreamingApiClient.GetPacketWriterClient();
+        var packetWriter = this.packetWriter;
         await packetWriter.WriteDataPacketAsync(
             new WriteDataPacketRequest
             {

--- a/docs/developer-resources/secu4/stream_api/reference_docs/getting-started/installation.md
+++ b/docs/developer-resources/secu4/stream_api/reference_docs/getting-started/installation.md
@@ -73,13 +73,14 @@ Verify your installation by running a simple test:
 using MA.Streaming.Proto.Client.Remote;
 
 var configuration = new StreamingApiConfiguration(StreamCreationStrategy.TopicBased, "localhost:9092", []);
-StreamingApiClient.Initialise(
+var streamingApiClient = StreamingApiClientFactory.Create(
     configuration,
     new CancellationTokenSourceProvider(),
     new KafkaBrokerAvailabilityChecker(),
     new LoggingDirectoryProvider(@"C:\Temp"));
+streamingApiClient.Initialise();
 
-var connectionManager = StreamingApiClient.GetConnectionManagerClient();
+var connectionManager = streamingApiClient.GetConnectionManagerClient();
 // Test basic connectivity
 var connections = await connectionManager.GetConnection();
 ```

--- a/docs/developer-resources/secu4/stream_api/reference_docs/getting-started/quick-start.md
+++ b/docs/developer-resources/secu4/stream_api/reference_docs/getting-started/quick-start.md
@@ -110,17 +110,18 @@ var config = new StreamingApiConfiguration(
     "localhost:9092", 
     []);
 
-StreamingApiClient.Initialise(
+var streamingApiClient = StreamingApiClientFactory.Create(
     config,
     new CancellationTokenSourceProvider(),
     new KafkaBrokerAvailabilityChecker(),
     new LoggingDirectoryProvider(@"C:\Temp"));
+streamingApiClient.Initialise();
 
 // Get service clients
-var sessionManager = StreamingApiClient.GetSessionManagementClient();
-var connectionManager = StreamingApiClient.GetConnectionManagerClient();
-var packetWriter = StreamingApiClient.GetPacketWriterClient();
-var packetReader = StreamingApiClient.GetPacketReaderClient();
+var sessionManager = streamingApiClient.GetSessionManagementClient();
+var connectionManager = streamingApiClient.GetConnectionManagerClient();
+var packetWriter = streamingApiClient.GetPacketWriterClient();
+var packetReader = streamingApiClient.GetPacketReaderClient();
 
 const string DataSource = "QuickStartDemo";
 

--- a/docs/developer-resources/secu4/stream_api/reference_docs/index.md
+++ b/docs/developer-resources/secu4/stream_api/reference_docs/index.md
@@ -49,8 +49,9 @@ The Stream API consists of five main services:
         integrateSessionManagement: true,
         batchingResponses: false);
 
-    StreamingApiClient.Initialise(streamConfiguration, cancellationTokenProvider, 
+    var streamingApiClient = StreamingApiClientFactory.Create(streamConfiguration, cancellationTokenProvider, 
         brokerChecker, loggingProvider);
+    streamingApiClient.Initialise();
     ```
 
 === "Remote Docker Server"

--- a/docs/developer-resources/secu4/stream_api/reference_docs/reference/api-reference.md
+++ b/docs/developer-resources/secu4/stream_api/reference_docs/reference/api-reference.md
@@ -98,8 +98,16 @@ message CloseConnectionResponse {
 ### Usage Examples
 
 ```csharp
+// Initialize client
+var streamingApiClient = StreamingApiClientFactory.Create(
+    new StreamingApiConfiguration(StreamCreationStrategy.TopicBased, "localhost:9092", []),
+    new CancellationTokenSourceProvider(),
+    new KafkaBrokerAvailabilityChecker(),
+    new LoggingDirectoryProvider(""));
+streamingApiClient.Initialise();
+
 // Create connection
-var connectionManager = StreamingApiClient.GetConnectionManagerClient();
+var connectionManager = streamingApiClient.GetConnectionManagerClient();
 var connection = await connectionManager.NewConnectionAsync(new NewConnectionRequest
 {
     Details = new ConnectionDetails
@@ -350,7 +358,14 @@ message UpdateSessionDetailsResponse {
 ### Usage Examples
 
 ```csharp
-var sessionManager = StreamingApiClient.GetSessionManagerClient();
+var streamingApiClient = StreamingApiClientFactory.Create(
+    new StreamingApiConfiguration(StreamCreationStrategy.TopicBased, "localhost:9092", []),
+    new CancellationTokenSourceProvider(),
+    new KafkaBrokerAvailabilityChecker(),
+    new LoggingDirectoryProvider(""));
+streamingApiClient.Initialise();
+
+var sessionManager = streamingApiClient.GetSessionManagementClient();
 
 // Create session
 var session = await sessionManager.CreateSessionAsync(new CreateSessionRequest
@@ -486,9 +501,16 @@ message WriteInfoPacketsResponse {
 
 ```csharp
 using MA.Streaming.OpenData;
-using MA.Streaming.API;
 
-var packetWriter = StreamingApiClient.GetPacketWriterClient();
+// Initialize client
+var streamingApiClient = StreamingApiClientFactory.Create(
+    new StreamingApiConfiguration(StreamCreationStrategy.TopicBased, "localhost:9092", []),
+    new CancellationTokenSourceProvider(),
+    new KafkaBrokerAvailabilityChecker(),
+    new LoggingDirectoryProvider(""));
+streamingApiClient.Initialise();
+
+var packetWriter = streamingApiClient.GetPacketWriterClient();
 
 // Create periodic data packet with parameter samples
 var timestamp = (ulong)DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() * 1000000; // nanoseconds
@@ -689,10 +711,18 @@ message ReadDataPacketsResponse {
 ```csharp
 using MA.Streaming.OpenData;
 
-var packetReader = StreamingApiClient.GetPacketReaderClient();
+// Initialize client
+var streamingApiClient = StreamingApiClientFactory.Create(
+    new StreamingApiConfiguration(StreamCreationStrategy.TopicBased, "localhost:9092", []),
+    new CancellationTokenSourceProvider(),
+    new KafkaBrokerAvailabilityChecker(),
+    new LoggingDirectoryProvider(""));
+streamingApiClient.Initialise();
+
+var packetReader = streamingApiClient.GetPacketReaderClient();
 
 // Get connection details first
-var connectionManager = StreamingApiClient.GetConnectionManagerClient();
+var connectionManager = streamingApiClient.GetConnectionManagerClient();
 var connectionResponse = await connectionManager.NewConnectionAsync(new NewConnectionRequest
 {
     Details = new ConnectionDetails
@@ -860,7 +890,14 @@ message GetEventResponse {
 ### Usage Examples
 
 ```csharp
-var dataFormatManager = StreamingApiClient.GetDataFormatManagerClient();
+var streamingApiClient = StreamingApiClientFactory.Create(
+    new StreamingApiConfiguration(StreamCreationStrategy.TopicBased, "localhost:9092", []),
+    new CancellationTokenSourceProvider(),
+    new KafkaBrokerAvailabilityChecker(),
+    new LoggingDirectoryProvider(""));
+streamingApiClient.Initialise();
+
+var dataFormatManager = streamingApiClient.GetDataFormatManagerClient();
 
 // Get parameter data format ID
 var parameterFormatResponse = await dataFormatManager.GetParameterDataFormatIdAsync(

--- a/docs/developer-resources/secu4/stream_api/reference_docs/reference/troubleshooting.md
+++ b/docs/developer-resources/secu4/stream_api/reference_docs/reference/troubleshooting.md
@@ -111,7 +111,14 @@ sudo ufw status
 **Diagnosis:**
 ```csharp
 // Check available sessions
-var sessionManager = StreamingApiClient.GetSessionManagerClient();
+var streamingApiClient = StreamingApiClientFactory.Create(
+    new StreamingApiConfiguration(StreamCreationStrategy.TopicBased, "localhost:9092", []),
+    new CancellationTokenSourceProvider(),
+    new KafkaBrokerAvailabilityChecker(),
+    new LoggingDirectoryProvider(""));
+streamingApiClient.Initialise();
+
+var sessionManager = streamingApiClient.GetSessionManagementClient();
 var sessions = await sessionManager.ListActiveSessionsAsync(new ListActiveSessionsRequest());
 ```
 

--- a/docs/developer-resources/secu4/stream_api/reference_docs/services/connection-management.md
+++ b/docs/developer-resources/secu4/stream_api/reference_docs/services/connection-management.md
@@ -36,7 +36,14 @@ Connections represent individual client access points to data streams. The servi
 ### Basic Connection Operations
 
 ```csharp
-var connectionManager = StreamingApiClient.GetConnectionManagerClient();
+var streamingApiClient = StreamingApiClientFactory.Create(
+    new StreamingApiConfiguration(StreamCreationStrategy.TopicBased, "localhost:9092", []),
+    new CancellationTokenSourceProvider(),
+    new KafkaBrokerAvailabilityChecker(),
+    new LoggingDirectoryProvider(""));
+streamingApiClient.Initialise();
+
+var connectionManager = streamingApiClient.GetConnectionManagerClient();
 
 // Create new connection
 var connection = await connectionManager.NewConnectionAsync(new NewConnectionRequest

--- a/docs/developer-resources/secu4/stream_api/reference_docs/services/data-format-management.md
+++ b/docs/developer-resources/secu4/stream_api/reference_docs/services/data-format-management.md
@@ -20,7 +20,14 @@ This service provides:
 ### Register Data Format
 #### Parameter List
 ```csharp
-var formatManager = StreamingApiClient.GetDataFormatManagerClient();
+var streamingApiClient = StreamingApiClientFactory.Create(
+    new StreamingApiConfiguration(StreamCreationStrategy.TopicBased, "localhost:9092", []),
+    new CancellationTokenSourceProvider(),
+    new KafkaBrokerAvailabilityChecker(),
+    new LoggingDirectoryProvider(""));
+streamingApiClient.Initialise();
+
+var formatManager = streamingApiClient.GetDataFormatManagerClient();
 
 var parameterListFormatRequest = new GetParameterDataFormatIdRequest
 {
@@ -35,7 +42,14 @@ var dataFormatIdentifier = response.DataFormatIdentifier;
 #### Event Identifier
 
 ```csharp
-var formatManager = StreamingApiClient.GetDataFormatManagerClient();
+var streamingApiClient = StreamingApiClientFactory.Create(
+    new StreamingApiConfiguration(StreamCreationStrategy.TopicBased, "localhost:9092", []),
+    new CancellationTokenSourceProvider(),
+    new KafkaBrokerAvailabilityChecker(),
+    new LoggingDirectoryProvider(""));
+streamingApiClient.Initialise();
+
+var formatManager = streamingApiClient.GetDataFormatManagerClient();
 
 var formatRequest = new GetEventDataFormatIdRequest
 {
@@ -49,7 +63,14 @@ var dataFormatIdentifier = response.DataFormatIdentifier;
 ### Get Data Format Definition
 #### Parameter List
 ```csharp
-var formatManager = StreamingApiClient.GetDataFormatManagerClient();
+var streamingApiClient = StreamingApiClientFactory.Create(
+    new StreamingApiConfiguration(StreamCreationStrategy.TopicBased, "localhost:9092", []),
+    new CancellationTokenSourceProvider(),
+    new KafkaBrokerAvailabilityChecker(),
+    new LoggingDirectoryProvider(""));
+streamingApiClient.Initialise();
+
+var formatManager = streamingApiClient.GetDataFormatManagerClient();
 
 var dataFormatIdentifier = 123456UL;
 var dataFormatResponse = await formatManager.GetParametersListAsync(new GetParametersListRequest
@@ -63,7 +84,14 @@ var parameterList = dataFormatResponse.Parameters;
 
 #### Event Identifier
 ```csharp
-var formatManager = StreamingApiClient.GetDataFormatManagerClient();
+var streamingApiClient = StreamingApiClientFactory.Create(
+    new StreamingApiConfiguration(StreamCreationStrategy.TopicBased, "localhost:9092", []),
+    new CancellationTokenSourceProvider(),
+    new KafkaBrokerAvailabilityChecker(),
+    new LoggingDirectoryProvider(""));
+streamingApiClient.Initialise();
+
+var formatManager = streamingApiClient.GetDataFormatManagerClient();
 
 var dataFormatIdentifier = 123456UL;
 var dataFormatResponse = await formatManager.GetEventAsync(new GetEventRequest

--- a/docs/developer-resources/secu4/stream_api/reference_docs/services/packet-reader.md
+++ b/docs/developer-resources/secu4/stream_api/reference_docs/services/packet-reader.md
@@ -28,7 +28,14 @@ The service offers flexible data consumption modes:
 ### Basic Stream Reading
 
 ```csharp
-var packetReader = StreamingApiClient.GetPacketReaderClient();
+var streamingApiClient = StreamingApiClientFactory.Create(
+    new StreamingApiConfiguration(StreamCreationStrategy.TopicBased, "localhost:9092", []),
+    new CancellationTokenSourceProvider(),
+    new KafkaBrokerAvailabilityChecker(),
+    new LoggingDirectoryProvider(""));
+streamingApiClient.Initialise();
+
+var packetReader = streamingApiClient.GetPacketReaderClient();
 
 // Start reading all packets from a connection
 var readRequest = new ReadPacketsRequest

--- a/docs/developer-resources/secu4/stream_api/reference_docs/services/packet-writer.md
+++ b/docs/developer-resources/secu4/stream_api/reference_docs/services/packet-writer.md
@@ -30,7 +30,14 @@ The service provides multiple writing modes optimized for different use cases:
 ### Single Packet Writing
 
 ```csharp
-var packetWriter = StreamingApiClient.GetPacketWriterClient();
+var streamingApiClient = StreamingApiClientFactory.Create(
+    new StreamingApiConfiguration(StreamCreationStrategy.TopicBased, "localhost:9092", []),
+    new CancellationTokenSourceProvider(),
+    new KafkaBrokerAvailabilityChecker(),
+    new LoggingDirectoryProvider(""));
+streamingApiClient.Initialise();
+
+var packetWriter = streamingApiClient.GetPacketWriterClient();
 
 // Write individual telemetry packet
 await packetWriter.WriteDataPacketAsync(new WriteDataPacketRequest

--- a/docs/developer-resources/secu4/stream_api/reference_docs/services/session-management.md
+++ b/docs/developer-resources/secu4/stream_api/reference_docs/services/session-management.md
@@ -35,7 +35,14 @@ Sessions represent logical groupings of data streams with associated metadata. T
 ### Basic Session Operations
 
 ```csharp
-var sessionManager = StreamingApiClient.GetSessionManagerClient();
+var streamingApiClient = StreamingApiClientFactory.Create(
+    new StreamingApiConfiguration(StreamCreationStrategy.TopicBased, "localhost:9092", []),
+    new CancellationTokenSourceProvider(),
+    new KafkaBrokerAvailabilityChecker(),
+    new LoggingDirectoryProvider(""));
+streamingApiClient.Initialise();
+
+var sessionManager = streamingApiClient.GetSessionManagementClient();
 
 // Create a new session
 var newSessionResponse = sessionManager.CreateSession(new CreateSessionRequest
@@ -165,7 +172,14 @@ The Session Management Service provides real-time notification streams that push
 Subscribe to receive notifications when new sessions are created for a specific data source:
 
 ```csharp
-var sessionManager = StreamingApiClient.GetSessionManagementClient();
+var streamingApiClient = StreamingApiClientFactory.Create(
+    new StreamingApiConfiguration(StreamCreationStrategy.TopicBased, "localhost:9092", []),
+    new CancellationTokenSourceProvider(),
+    new KafkaBrokerAvailabilityChecker(),
+    new LoggingDirectoryProvider(""));
+streamingApiClient.Initialise();
+
+var sessionManager = streamingApiClient.GetSessionManagementClient();
 
 // Create a streaming call to receive session start notifications
 var startNotificationStream = sessionManager.GetSessionStartNotification(
@@ -191,7 +205,14 @@ await foreach (var notification in startNotificationStream.ResponseStream.ReadAl
 Subscribe to receive notifications when sessions are terminated:
 
 ```csharp
-var sessionManager = StreamingApiClient.GetSessionManagementClient();
+var streamingApiClient = StreamingApiClientFactory.Create(
+    new StreamingApiConfiguration(StreamCreationStrategy.TopicBased, "localhost:9092", []),
+    new CancellationTokenSourceProvider(),
+    new KafkaBrokerAvailabilityChecker(),
+    new LoggingDirectoryProvider(""));
+streamingApiClient.Initialise();
+
+var sessionManager = streamingApiClient.GetSessionManagementClient();
 
 // Create a streaming call to receive session stop notifications
 var stopNotificationStream = sessionManager.GetSessionStopNotification(
@@ -217,7 +238,14 @@ await foreach (var notification in stopNotificationStream.ResponseStream.ReadAll
 Monitor both session start and stop events concurrently:
 
 ```csharp
-var sessionManager = StreamingApiClient.GetSessionManagementClient();
+var streamingApiClient = StreamingApiClientFactory.Create(
+    new StreamingApiConfiguration(StreamCreationStrategy.TopicBased, "localhost:9092", []),
+    new CancellationTokenSourceProvider(),
+    new KafkaBrokerAvailabilityChecker(),
+    new LoggingDirectoryProvider(""));
+streamingApiClient.Initialise();
+
+var sessionManager = streamingApiClient.GetSessionManagementClient();
 var cancellationToken = new CancellationToken();
 
 // Start monitoring session lifecycle

--- a/docs/developer-resources/secu4/stream_api/reference_docs/services/session-management.md
+++ b/docs/developer-resources/secu4/stream_api/reference_docs/services/session-management.md
@@ -160,7 +160,7 @@ var sessionInfo = await sessionManager.GetSessionInfoAsync(
     });
 
 // List all sessions
-var activeSessions = await sessionManager.GetCurrentSessionsAsync(new GetCurrentSessionsRequest());
+var activeSessions = await sessionManager.GetCurrentSessionsAsync(new GetCurrentSessionsRequest() { DataSource = "DataSource" });
 ```
 
 ### Session Notifications

--- a/docs/developer-resources/secu4/support_library/reference_docs/index.md
+++ b/docs/developer-resources/secu4/support_library/reference_docs/index.md
@@ -291,6 +291,8 @@ reader.Start();  // Now start reading - pipeline is ready!
 ```csharp
 using MA.DataPlatforms.Streaming.Support.Lib.Core.Abstractions;
 using MA.DataPlatforms.Streaming.Support.Lib.Core.Contracts;
+using MA.DataPlatforms.Streaming.Support.Lib.Core.Shared;
+using MA.Streaming.Abstraction;
 using MA.Streaming.Core.Configs;
 
 var logger = new ConsoleLogger();
@@ -405,6 +407,12 @@ var eventResult = dataFormatService.GetEventDataFormatId(
 ```
 
 #### 5. Read Data
+
+!!! note
+    You will need to spin / wait on the main thread as the Reader Service reads packets or the application will exit.
+    For example: while(true) { await Task.Delay(1000); }
+
+    See [Reader Module](reader-module.md) for a more complete example including handling session start / completion events.
 
 ```csharp
 // Get the reader API


### PR DESCRIPTION
Various updates to Open Streaming example docs to match latest version.

Changes:
- Update Streaming API example code everywhere to match StreamingApiClientFactory pattern
- Session query example code updated to suggest DataSource must be set
- Minor changes to support library reference (missing usings, warn reader service is threaded and that the main thread must not terminate before it is done)